### PR TITLE
Apply missing spec implementation for etchash_get_seedhash

### DIFF
--- a/src/libetchash/internal.c
+++ b/src/libetchash/internal.c
@@ -285,7 +285,8 @@ etchash_h256_t etchash_get_seedhash(uint64_t block_number)
 {
 	etchash_h256_t ret;
 	etchash_h256_reset(&ret);
-	uint64_t const epochs = get_epoch_number(block_number);
+	// Applied the specification from https://github.com/ethereumclassic/ECIPs/blob/master/_specs/ecip-1099.md#specification
+	uint64_t const epochs = block_number / ETCHASH_EPOCH_LENGTH;
 	for (uint32_t i = 0; i < epochs; ++i)
 		SHA3_256(&ret, (uint8_t*)&ret, 32);
 	return ret;


### PR DESCRIPTION
While reading the [spec](https://github.com/ethereumclassic/ECIPs/blob/master/_specs/ecip-1099.md#specification) I found the following part which wasn't applied.

```
// seedHash is the seed to use for generating a verification cache and the
// mining dataset. The block number passed should represent an epoch boundary + 1
// calculated as `block = epoch * [old/new]EpochLength + 1`
// pre-1099: block = epoch * oldEpochLength + 1 OR block = currentBlock.number
// 1099: block = epoch * newEpochLength + 1
func seedHash(block uint64) []byte {
  seed := make([]byte, 32)
  if block < oldEpochLength {
    return seed
  }
  // keep using oldEpochLength here so seeds don't overlap
  keccak256 := makeHasher(sha3.NewLegacyKeccak256())
  for i := 0; i < int(block/oldEpochLength); i++ {
    keccak256(seed, seed)
  }
  return seed
}
```

@Grizzly1127 can you test it?